### PR TITLE
Update nginx-ingress-certificate-manager.md

### DIFF
--- a/ru/_tutorials/containers/nginx-ingress-certificate-manager.md
+++ b/ru/_tutorials/containers/nginx-ingress-certificate-manager.md
@@ -143,22 +143,23 @@
      -o json | jq -r '.spec.versions[].name'
    ```
 
-1. Создайте хранилище секретов с именем `secret-store`, содержащее секрет `yc-auth`, указав поддерживаемую `apiVersion`:
+1. Создайте хранилище секретов с именем `yc-cert-manager`, содержащее секрет `yc-auth`, указав поддерживаемую `apiVersion`:
 
 
    ```bash
    kubectl --namespace ns apply -f - <<< '
    apiVersion: external-secrets.io/v1beta1
-   kind: SecretStore
+   kind: ClusterSecretStore
    metadata:
-     name: secret-store
+     name: yc-cert-manager
    spec:
      provider:
        yandexcertificatemanager:
          auth:
            authorizedKeySecretRef:
              name: yc-auth
-             key: authorized-key'
+             key: authorized-key.json
+             namespace: ns'
    ```
 
 
@@ -183,8 +184,8 @@
    spec:
      refreshInterval: 1h
      secretStoreRef:
-       name: secret-store
-       kind: SecretStore
+       name: yc-cert-manager
+       kind: ClusterSecretStore
      target:
        name: k8s-secret
        template:

--- a/ru/_tutorials/containers/nginx-ingress-certificate-manager.md
+++ b/ru/_tutorials/containers/nginx-ingress-certificate-manager.md
@@ -149,7 +149,7 @@
    ```bash
    kubectl --namespace ns apply -f - <<< '
    apiVersion: external-secrets.io/v1beta1
-   kind: ClusterSecretStore
+   kind: SecretStore
    metadata:
      name: yc-cert-manager
    spec:
@@ -162,7 +162,11 @@
              namespace: ns'
    ```
 
+   {% note tip %}
 
+   В примере хранилище секретов создается с типом `kind: SecretStore`, оно будет доступно только в пространстве имен `ns`, в котором было создано. Чтобы хранилище секретов было доступно во всех пространствах имен, используйте тип `kind: ClusterSecretStore`.
+
+   {% endnote %}
 
 ## Создайте ExternalSecret {#create-externalsecret}
 
@@ -185,7 +189,7 @@
      refreshInterval: 1h
      secretStoreRef:
        name: yc-cert-manager
-       kind: ClusterSecretStore
+       kind: SecretStore
      target:
        name: k8s-secret
        template:
@@ -200,6 +204,12 @@
          key: <идентификатор_сертификата>
          property: privateKey'
    ```
+
+   {% note info %}
+
+   Если вы создавали хранилище секретов с типом `kind: ClusterSecretStore`, исправьте в примере манифеста значение `spec:secretStoreRef:kind` на `ClusterSecretStore`.
+
+   {% endnote %}
 
    Где:
    * `k8s-secret` — имя секрета, в который External Secret Operator поместит сертификат из {{ certificate-manager-name }}.


### PR DESCRIPTION
Changed name of secret-store.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
1. Changed SecretStore name to use secret for access to yandex cert manager to yc-cert-manager.
2. Changed storage type from SecretStore to ClusterSecretStore to be able to use yc-cert-manager from any namespace.
3. Fixed error in .spec.provider.yandexcertificatemanager.auth.authorizedKeySecretRef.key. In the example in the yc-auth secret  value is stored in authorized-key.json field